### PR TITLE
Improve error message for empty containers and tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,3 @@ docs/yarn-error.log
 
 tools/log-viewer/log.json
 tools/viz-tool/log.json
-

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ classes/
 ### IntelliJ
 /.idea/
 out
-
+*.iml
 
 ### NodeJS
 node_modules/
@@ -44,3 +44,4 @@ docs/yarn-error.log
 
 tools/log-viewer/log.json
 tools/viz-tool/log.json
+

--- a/app/src/main/kotlin/batect/config/io/ConfigurationFile.kt
+++ b/app/src/main/kotlin/batect/config/io/ConfigurationFile.kt
@@ -19,6 +19,7 @@ package batect.config.io
 import batect.config.Configuration
 import batect.config.Container
 import batect.config.ContainerMap
+import batect.config.Task
 import batect.config.TaskMap
 
 data class ConfigurationFile(
@@ -31,7 +32,7 @@ data class ConfigurationFile(
 
         return Configuration(
             resolveProjectName(pathResolver),
-            TaskMap(tasks.map { (name, task) -> task.toTask(name) }),
+            TaskMap(tasks.map { (name, task) -> fromFileToTaskConfiguration(name, task) }),
             ContainerMap(containers.map { (name, container) -> fromFileToContainerConfiguration(name, container, pathResolver) }))
     }
 
@@ -41,6 +42,14 @@ data class ConfigurationFile(
         }
 
         return fileContainerConfig.toContainer(containerName, pathResolver)
+    }
+
+    private fun fromFileToTaskConfiguration(taskName: String, fileTaskConfig: TaskFromFile?): Task {
+        if (fileTaskConfig == null) {
+            throw ConfigurationException("Task '$taskName' is invalid: no properties have been provided, container is required")
+        }
+
+        return fileTaskConfig.toTask(taskName)
     }
 
     private fun resolveProjectName(pathResolver: PathResolver): String {

--- a/app/src/main/kotlin/batect/config/io/ConfigurationFile.kt
+++ b/app/src/main/kotlin/batect/config/io/ConfigurationFile.kt
@@ -35,7 +35,7 @@ data class ConfigurationFile(
             ContainerMap(containers.map { (name, container) -> fromFileToContainerConfiguration(name, container, pathResolver) }))
     }
 
-    private fun fromFileToContainerConfiguration(containerName: String, fileContainerConfig: ContainerFromFile, pathResolver: PathResolver): Container {
+    private fun fromFileToContainerConfiguration(containerName: String, fileContainerConfig: ContainerFromFile?, pathResolver: PathResolver): Container {
         if (fileContainerConfig == null) {
             throw ConfigurationException("Container '$containerName' is invalid: no properties have been provided. At least one of image or build_directory is required")
         }
@@ -51,6 +51,7 @@ data class ConfigurationFile(
         if (pathResolver.relativeTo.root == pathResolver.relativeTo) {
             throw ConfigurationException("No project name has been given explicitly, but the configuration file is in the root directory and so a project name cannot be inferred.")
         }
+
         return pathResolver.relativeTo.fileName.toString()
     }
 }

--- a/app/src/main/kotlin/batect/config/io/ConfigurationLoader.kt
+++ b/app/src/main/kotlin/batect/config/io/ConfigurationLoader.kt
@@ -56,6 +56,7 @@ class ConfigurationLoader(
         }
 
         Files.newInputStream(path, StandardOpenOption.READ).use {
+
             val config = loadConfig(it, path)
 
             logger.info {

--- a/app/src/main/kotlin/batect/config/io/ConfigurationLoader.kt
+++ b/app/src/main/kotlin/batect/config/io/ConfigurationLoader.kt
@@ -56,7 +56,6 @@ class ConfigurationLoader(
         }
 
         Files.newInputStream(path, StandardOpenOption.READ).use {
-
             val config = loadConfig(it, path)
 
             logger.info {

--- a/app/src/test/kotlin/batect/config/io/ConfigurationLoaderSpec.kt
+++ b/app/src/test/kotlin/batect/config/io/ConfigurationLoaderSpec.kt
@@ -793,5 +793,22 @@ object ConfigurationLoaderSpec : Spek({
                 assertThat({ loadConfiguration(config) }, throws(withMessage("Could not load configuration file: Container 'container-2' is invalid: no properties have been provided. At least one of image or build_directory is required")))
             }
         }
+
+        on("loading a configuration file with an empty task") {
+            val config = """
+                |project_name: the_cool_project
+                |
+                |containers:
+                |  container-1:
+                |    build_directory: container-1
+                |tasks:
+                |   task-1:
+                |
+                """.trimMargin()
+
+            it("should fail with an error message") {
+                assertThat({ loadConfiguration(config) }, throws(withMessage("Could not load configuration file: Task 'task-1' is invalid: no properties have been provided, container is required")))
+            }
+        }
     }
 })

--- a/app/src/test/kotlin/batect/config/io/ConfigurationLoaderSpec.kt
+++ b/app/src/test/kotlin/batect/config/io/ConfigurationLoaderSpec.kt
@@ -777,5 +777,21 @@ object ConfigurationLoaderSpec : Spek({
                 assertThat({ loader.loadConfig("/doesntexist.yml") }, throws(withMessage("The file '/doesntexist.yml' does not exist.")))
             }
         }
+
+        on("loading a configuration file with an empty container") {
+            val config = """
+                |project_name: the_cool_project
+                |
+                |containers:
+                |  container-1:
+                |    build_directory: container-1
+                |  container-2:
+                |
+                """.trimMargin()
+
+            it("should fail with an error message") {
+                assertThat({ loadConfiguration(config) }, throws(withMessage("Could not load configuration file: Container 'container-2' is invalid: no properties have been provided. At least one of image or build_directory is required")))
+            }
+        }
     }
 })


### PR DESCRIPTION
Fixes #4 
It was assumed the containers were always defined in the config file, but when only the name of the container is defined, Jackson converts it to an entry with null as the value. 

```yaml
containers:
  my-container:
```

This PR checks whether the container exists [before transforming](https://github.com/charleskorn/batect/blob/master/app/src/main/kotlin/batect/config/io/ConfigurationFile.kt#L32) it to prevent the `NullPointerException` and produce a more user friendly error message.