### PR TITLE
Add BATECT_QUIET_DOWNLOAD env flag for ignoring the -# switch

### DIFF
--- a/wrapper/src/template.sh
+++ b/wrapper/src/template.sh
@@ -36,7 +36,13 @@
         echo "Downloading batect version $VERSION from $DOWNLOAD_URL..."
         mkdir -p "$CACHE_DIR"
         temp_file=$(mktemp)
-        curl -# --fail --show-error --location --output "$temp_file" "$DOWNLOAD_URL"
+
+        if [[ $BATECT_QUIET_DOWNLOAD == 'true' ]]; then
+            curl --fail --show-error --location --output "$temp_file" "$DOWNLOAD_URL"
+        else
+            curl -# --fail --show-error --location --output "$temp_file" "$DOWNLOAD_URL"
+        fi
+
         mv "$temp_file" "$JAR_PATH"
     }
 

--- a/wrapper/src/template.sh
+++ b/wrapper/src/template.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 
 {
-    BATECT_QUIET_DOWNLOAD=${BATECT_QUIET_DOWNLOAD:-false}
-
     set -euo pipefail
 
     # This file is part of batect.
@@ -13,6 +11,7 @@
     VERSION="VERSION-GOES-HERE"
     DOWNLOAD_URL_ROOT=${BATECT_DOWNLOAD_URL_ROOT:-"https://dl.bintray.com/charleskorn/batect"}
     DOWNLOAD_URL=${BATECT_DOWNLOAD_URL:-"$DOWNLOAD_URL_ROOT/$VERSION/bin/batect-$VERSION.jar"}
+    QUIET_DOWNLOAD=${BATECT_QUIET_DOWNLOAD:-false}
 
     ROOT_CACHE_DIR=${BATECT_CACHE_DIR:-"$HOME/.batect/cache"}
     CACHE_DIR="$ROOT_CACHE_DIR/$VERSION"
@@ -39,7 +38,7 @@
         mkdir -p "$CACHE_DIR"
         temp_file=$(mktemp)
 
-        if [[ $BATECT_QUIET_DOWNLOAD == 'true' ]]; then
+        if [[ $QUIET_DOWNLOAD == 'true' ]]; then
             curl --fail --show-error --location --output "$temp_file" "$DOWNLOAD_URL"
         else
             curl -# --fail --show-error --location --output "$temp_file" "$DOWNLOAD_URL"

--- a/wrapper/src/template.sh
+++ b/wrapper/src/template.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 
 {
+    if [ -z "$BATECT_QUIET_DOWNLOAD" ]; then
+        DO_QUIET='false'
+    else
+        DO_QUIET=$BATECT_QUIET_DOWNLOAD
+    fi
+
     set -euo pipefail
 
     # This file is part of batect.
@@ -37,7 +43,7 @@
         mkdir -p "$CACHE_DIR"
         temp_file=$(mktemp)
 
-        if [[ $BATECT_QUIET_DOWNLOAD == 'true' ]]; then
+        if [[ $DO_QUIET == 'true' ]]; then
             curl --fail --show-error --location --output "$temp_file" "$DOWNLOAD_URL"
         else
             curl -# --fail --show-error --location --output "$temp_file" "$DOWNLOAD_URL"

--- a/wrapper/src/template.sh
+++ b/wrapper/src/template.sh
@@ -1,11 +1,7 @@
 #!/usr/bin/env bash
 
 {
-    if [ -z "$BATECT_QUIET_DOWNLOAD" ]; then
-        DO_QUIET='false'
-    else
-        DO_QUIET=$BATECT_QUIET_DOWNLOAD
-    fi
+    BATECT_QUIET_DOWNLOAD=${BATECT_QUIET_DOWNLOAD:-false}
 
     set -euo pipefail
 
@@ -43,7 +39,7 @@
         mkdir -p "$CACHE_DIR"
         temp_file=$(mktemp)
 
-        if [[ $DO_QUIET == 'true' ]]; then
+        if [[ $BATECT_QUIET_DOWNLOAD == 'true' ]]; then
             curl --fail --show-error --location --output "$temp_file" "$DOWNLOAD_URL"
         else
             curl -# --fail --show-error --location --output "$temp_file" "$DOWNLOAD_URL"

--- a/wrapper/test/tests.py
+++ b/wrapper/test/tests.py
@@ -56,6 +56,26 @@ class WrapperScriptTests(unittest.TestCase):
         self.assertIn("404 File not found", result.stdout.decode())
         self.assertNotEqual(result.returncode, 0)
 
+    def test_download_is_not_quiet(self):
+        result = self.run_script([], download_url=self.default_download_url, quiet_download="false")
+        result_output = result.stdout.decode()
+
+        self.assertIn("Downloading batect", result_output)
+        self.assertIn("BATECT_WRAPPER_SCRIPT_DIR is: {}\n".format(self.get_script_dir()), result_output)
+        self.assertIn("HOSTNAME is: {}\n".format(socket.gethostname()), result_output)
+        self.assertIn("#", result_output)
+        self.assertEqual(result.returncode, 0)
+
+    def test_download_is_quiet(self):
+        result = self.run_script([], download_url=self.default_download_url, quiet_download="true")
+        result_output = result.stdout.decode()
+
+        self.assertIn("Downloading batect", result_output)
+        self.assertIn("BATECT_WRAPPER_SCRIPT_DIR is: {}\n".format(self.get_script_dir()), result_output)
+        self.assertIn("HOSTNAME is: {}\n".format(socket.gethostname()), result_output)
+        self.assertNotIn("#", result_output)
+        self.assertEqual(result.returncode, 0)
+
     def test_no_curl(self):
         path_dir = self.create_limited_path(["/usr/bin/basename", "/usr/bin/dirname"])
 
@@ -111,11 +131,12 @@ class WrapperScriptTests(unittest.TestCase):
 
         return path_dir + ":/bin"
 
-    def run_script(self, args, download_url=default_download_url, path=os.environ["PATH"]):
+    def run_script(self, args, download_url=default_download_url, path=os.environ["PATH"], quiet_download="false"):
         env = {
             "BATECT_CACHE_DIR": self.cache_dir,
             "BATECT_DOWNLOAD_URL": download_url,
-            "PATH": path
+            "PATH": path,
+            "BATECT_QUIET_DOWNLOAD": quiet_download
         }
 
         path = self.get_script_path()

--- a/wrapper/test/tests.py
+++ b/wrapper/test/tests.py
@@ -131,13 +131,14 @@ class WrapperScriptTests(unittest.TestCase):
 
         return path_dir + ":/bin"
 
-    def run_script(self, args, download_url=default_download_url, path=os.environ["PATH"], quiet_download="false"):
+    def run_script(self, args, download_url=default_download_url, path=os.environ["PATH"], quiet_download="undefined"):
         env = {
             "BATECT_CACHE_DIR": self.cache_dir,
             "BATECT_DOWNLOAD_URL": download_url,
-            "PATH": path,
-            "BATECT_QUIET_DOWNLOAD": quiet_download
+            "PATH": path
         }
+        if quiet_download != "undefined":
+            env["BATECT_QUIET_DOWNLOAD"] = quiet_download
 
         path = self.get_script_path()
         command = [path] + args

--- a/wrapper/test/tests.py
+++ b/wrapper/test/tests.py
@@ -131,13 +131,13 @@ class WrapperScriptTests(unittest.TestCase):
 
         return path_dir + ":/bin"
 
-    def run_script(self, args, download_url=default_download_url, path=os.environ["PATH"], quiet_download="undefined"):
+    def run_script(self, args, download_url=default_download_url, path=os.environ["PATH"], quiet_download=None):
         env = {
             "BATECT_CACHE_DIR": self.cache_dir,
             "BATECT_DOWNLOAD_URL": download_url,
             "PATH": path
         }
-        if quiet_download != "undefined":
+        if quiet_download is not None:
             env["BATECT_QUIET_DOWNLOAD"] = quiet_download
 
         path = self.get_script_path()


### PR DESCRIPTION
Reference to issue: #126 

Rather than going for a `--quiet`/`-q` command line switch, I steered towards an environment variable instead. This way, we don't have a confusing parity between what's considered command line arguments for the wrapper and what's a command line argument for the actual batect. 

If in the future, we added more `--quiet` implementations for the actual batect CLI, then maybe it could include the `-#` quiet mode as well (or some sort of verbosity)
