### PR TITLE
Add support for device mounting

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,7 +34,6 @@ If there's something you're really keen to see, pull requests are always welcome
 * some way to clean up old images when they're no longer needed
 * allow tasks to not start any containers if they just have prerequisites (eg. pre-commit task)
 * some way to reference another Dockerfile as the base image for a Dockerfile
-* allow giving access to a specific devices (`--device` - https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities)
 * support setting `ulimit` values (`--ulimit` - https://docs.docker.com/engine/reference/commandline/run/#set-ulimits-in-container---ulimit)
 * allow `home_directory` to match local user's home directory path
 * allow `working_directory` and container side of volume mount to reference home directory (inside container)

--- a/app/src/integrationTest/kotlin/batect/integrationtests/DockerClientIntegrationTest.kt
+++ b/app/src/integrationTest/kotlin/batect/integrationtests/DockerClientIntegrationTest.kt
@@ -16,6 +16,7 @@
 
 package batect.integrationtests
 
+import batect.config.DeviceMount
 import batect.config.HealthCheckConfig
 import batect.config.PortMapping
 import batect.config.VolumeMount
@@ -102,7 +103,15 @@ object DockerClientIntegrationTest : Spek({
         val nativeMethods by createForGroup { getNativeMethodsForPlatform(posix) }
         val client by createForGroup { createClient(posix, nativeMethods) }
 
-        fun creationRequestForContainer(image: DockerImage, network: DockerNetwork, command: List<String>, volumeMounts: Set<VolumeMount> = emptySet(), portMappings: Set<PortMapping> = emptySet(), userAndGroup: UserAndGroup? = null): DockerContainerCreationRequest {
+        fun creationRequestForContainer(
+            image: DockerImage,
+            network: DockerNetwork,
+            command: List<String>,
+            volumeMounts: Set<VolumeMount> = emptySet(),
+            deviceMounts: Set<DeviceMount> = emptySet(),
+            portMappings: Set<PortMapping> = emptySet(),
+            userAndGroup: UserAndGroup? = null
+        ): DockerContainerCreationRequest {
             return DockerContainerCreationRequest(
                 image,
                 network,
@@ -113,6 +122,7 @@ object DockerClientIntegrationTest : Spek({
                 emptyMap(),
                 null,
                 volumeMounts,
+                deviceMounts,
                 portMappings,
                 HealthCheckConfig(),
                 userAndGroup,

--- a/app/src/main/kotlin/batect/config/Container.kt
+++ b/app/src/main/kotlin/batect/config/Container.kt
@@ -50,6 +50,7 @@ data class Container(
     val environment: Map<String, EnvironmentVariableExpression> = emptyMap(),
     val workingDirectory: String? = null,
     val volumeMounts: Set<VolumeMount> = emptySet(),
+    val deviceMounts: Set<DeviceMount> = emptySet(),
     val portMappings: Set<PortMapping> = emptySet(),
     val dependencies: Set<String> = emptySet(),
     val healthCheckConfig: HealthCheckConfig = HealthCheckConfig(),
@@ -72,6 +73,7 @@ data class Container(
         private const val environmentFieldName = "environment"
         private const val workingDirectoryFieldName = "working_directory"
         private const val volumeMountsFieldName = "volumes"
+        private const val deviceMountsFieldName = "devices"
         private const val portMappingsFieldName = "ports"
         private const val dependenciesFieldName = "dependencies"
         private const val healthCheckConfigFieldName = "health_check"
@@ -94,6 +96,7 @@ data class Container(
                 addElement(environmentFieldName, isOptional = true)
                 addElement(workingDirectoryFieldName, isOptional = true)
                 addElement(volumeMountsFieldName, isOptional = true)
+                addElement(deviceMountsFieldName, isOptional = true)
                 addElement(portMappingsFieldName, isOptional = true)
                 addElement(dependenciesFieldName, isOptional = true)
                 addElement(healthCheckConfigFieldName, isOptional = true)
@@ -116,6 +119,7 @@ data class Container(
         private val environmentFieldIndex = descriptor.getElementIndex(environmentFieldName)
         private val workingDirectoryFieldIndex = descriptor.getElementIndex(workingDirectoryFieldName)
         private val volumeMountsFieldIndex = descriptor.getElementIndex(volumeMountsFieldName)
+        private val deviceMountsFieldIndex = descriptor.getElementIndex(deviceMountsFieldName)
         private val portMappingsFieldIndex = descriptor.getElementIndex(portMappingsFieldName)
         private val dependenciesFieldIndex = descriptor.getElementIndex(dependenciesFieldName)
         private val healthCheckConfigFieldIndex = descriptor.getElementIndex(healthCheckConfigFieldName)
@@ -143,6 +147,7 @@ data class Container(
             var environment = emptyMap<String, EnvironmentVariableExpression>()
             var workingDirectory: String? = null
             var volumeMounts = emptySet<VolumeMount>()
+            var deviceMounts = emptySet<DeviceMount>()
             var portMappings = emptySet<PortMapping>()
             var dependencies = emptySet<String>()
             var healthCheckConfig = HealthCheckConfig()
@@ -166,6 +171,7 @@ data class Container(
                     environmentFieldIndex -> environment = input.decode(EnvironmentSerializer)
                     workingDirectoryFieldIndex -> workingDirectory = input.decodeStringElement(descriptor, i)
                     volumeMountsFieldIndex -> volumeMounts = input.decode(VolumeMount.serializer().set)
+                    deviceMountsFieldIndex -> deviceMounts = input.decode(DeviceMount.serializer().set)
                     portMappingsFieldIndex -> portMappings = input.decode(PortMapping.serializer().set)
                     dependenciesFieldIndex -> dependencies = input.decode(DependencySetSerializer)
                     healthCheckConfigFieldIndex -> healthCheckConfig = input.decode(HealthCheckConfig.serializer())
@@ -189,6 +195,7 @@ data class Container(
                 environment,
                 workingDirectory,
                 volumeMounts,
+                deviceMounts,
                 portMappings,
                 dependencies,
                 healthCheckConfig,
@@ -268,6 +275,7 @@ data class Container(
             output.encodeSerializableElement(descriptor, environmentFieldIndex, EnvironmentSerializer, obj.environment)
             output.encodeSerializableElement(descriptor, workingDirectoryFieldIndex, StringSerializer.nullable, obj.workingDirectory)
             output.encodeSerializableElement(descriptor, volumeMountsFieldIndex, VolumeMount.serializer().set, obj.volumeMounts)
+            output.encodeSerializableElement(descriptor, deviceMountsFieldIndex, DeviceMount.serializer().set, obj.deviceMounts)
             output.encodeSerializableElement(descriptor, portMappingsFieldIndex, PortMapping.serializer().set, obj.portMappings)
             output.encodeSerializableElement(descriptor, dependenciesFieldIndex, DependencySetSerializer, obj.dependencies)
             output.encodeSerializableElement(descriptor, healthCheckConfigFieldIndex, HealthCheckConfig.serializer(), obj.healthCheckConfig)

--- a/app/src/main/kotlin/batect/config/DeviceMount.kt
+++ b/app/src/main/kotlin/batect/config/DeviceMount.kt
@@ -1,0 +1,137 @@
+/*
+   Copyright 2017-2019 Charles Korn.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package batect.config
+
+import batect.config.io.ConfigurationException
+import batect.config.io.deserializers.tryToDeserializeWith
+import com.charleskorn.kaml.YamlInput
+import kotlinx.serialization.CompositeDecoder
+import kotlinx.serialization.Decoder
+import kotlinx.serialization.Encoder
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialDescriptor
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.Serializer
+import kotlinx.serialization.internal.SerialClassDescImpl
+import kotlinx.serialization.internal.StringDescriptor
+import kotlinx.serialization.internal.StringSerializer
+import kotlinx.serialization.internal.nullable
+
+@Serializable(with = DeviceMount.Companion::class)
+data class DeviceMount(
+    val localPath: String,
+    val containerPath: String,
+    val options: String? = null
+) {
+    override fun toString(): String {
+        if (options == null) {
+            return "$localPath:$containerPath"
+        } else {
+            return "$localPath:$containerPath:$options"
+        }
+    }
+
+    @Serializer(forClass = DeviceMount::class)
+    companion object : KSerializer<DeviceMount> {
+        override val descriptor: SerialDescriptor = object : SerialClassDescImpl("DeviceMount") {
+            init {
+                addElement("local")
+                addElement("container")
+                addElement("options", isOptional = true)
+            }
+        }
+
+        private val localPathFieldIndex = descriptor.getElementIndex("local")
+        private val containerPathFieldIndex = descriptor.getElementIndex("container")
+        private val optionsFieldIndex = descriptor.getElementIndex("options")
+
+        override fun deserialize(decoder: Decoder): DeviceMount {
+            if (decoder !is YamlInput) {
+                throw UnsupportedOperationException("Can only deserialize from YAML source.")
+            }
+
+            return decoder.tryToDeserializeWith(descriptor) { deserializeFromObject(it) }
+                ?: decoder.tryToDeserializeWith(StringDescriptor) { deserializeFromString(it) }
+                ?: throw ConfigurationException("Device mount definition is not valid. It must either be an object or a literal in the form 'local_path:container_path' or 'local_path:container_path:options'.")
+        }
+
+        private fun deserializeFromString(input: YamlInput): DeviceMount {
+            val value = input.decodeString()
+
+            if (value == "") {
+                throw ConfigurationException("Device mount definition cannot be empty.", input.node.location.line, input.node.location.column)
+            }
+
+            val regex = """(([a-zA-Z]:\\)?[^:]+):([^:]+)(:([^:]+))?""".toRegex()
+            val match = regex.matchEntire(value)
+
+            if (match == null) {
+                throw invalidMountDefinitionException(value, input)
+            }
+
+            val local = match.groupValues[1]
+            val container = match.groupValues[3]
+            val options = match.groupValues[5].takeIf { it.isNotEmpty() }
+
+            return DeviceMount(local, container, options)
+        }
+
+        private fun invalidMountDefinitionException(value: String, input: YamlInput) =
+            ConfigurationException(
+                "Device mount definition '$value' is not valid. It must be in the form 'local_path:container_path' or 'local_path:container_path:options'.",
+                input.node.location.line,
+                input.node.location.column
+            )
+
+        private fun deserializeFromObject(input: YamlInput): DeviceMount {
+            var localPath: String? = null
+            var containerPath: String? = null
+            var options: String? = null
+
+            loop@ while (true) {
+                when (val i = input.decodeElementIndex(descriptor)) {
+                    CompositeDecoder.READ_DONE -> break@loop
+                    localPathFieldIndex -> localPath = input.decodeStringElement(descriptor, i)
+                    containerPathFieldIndex -> containerPath = input.decodeStringElement(descriptor, i)
+                    optionsFieldIndex -> options = input.decodeStringElement(descriptor, i)
+                    else -> throw SerializationException("Unknown index $i")
+                }
+            }
+
+            if (localPath == null) {
+                throw ConfigurationException("Field '${descriptor.getElementName(localPathFieldIndex)}' is required but it is missing.", input.node.location.line, input.node.location.column)
+            }
+
+            if (containerPath == null) {
+                throw ConfigurationException("Field '${descriptor.getElementName(containerPathFieldIndex)}' is required but it is missing.", input.node.location.line, input.node.location.column)
+            }
+
+            return DeviceMount(localPath, containerPath, options)
+        }
+
+        override fun serialize(encoder: Encoder, obj: DeviceMount) {
+            val output = encoder.beginStructure(descriptor)
+
+            output.encodeStringElement(descriptor, localPathFieldIndex, obj.localPath)
+            output.encodeStringElement(descriptor, containerPathFieldIndex, obj.containerPath)
+            output.encodeSerializableElement(descriptor, optionsFieldIndex, StringSerializer.nullable, obj.options)
+
+            output.endStructure(descriptor)
+        }
+    }
+}

--- a/app/src/main/kotlin/batect/docker/DockerContainerCreationRequest.kt
+++ b/app/src/main/kotlin/batect/docker/DockerContainerCreationRequest.kt
@@ -18,6 +18,7 @@ package batect.docker
 
 import batect.config.HealthCheckConfig
 import batect.config.PortMapping
+import batect.config.DeviceMount
 import batect.config.VolumeMount
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonArray
@@ -35,6 +36,7 @@ data class DockerContainerCreationRequest(
     val environmentVariables: Map<String, String>,
     val workingDirectory: String?,
     val volumeMounts: Set<VolumeMount>,
+    val deviceMounts: Set<DeviceMount>,
     val portMappings: Set<PortMapping>,
     val healthCheckConfig: HealthCheckConfig,
     val userAndGroup: UserAndGroup?,
@@ -75,6 +77,7 @@ data class DockerContainerCreationRequest(
             "HostConfig" to json {
                 "NetworkMode" to network.id
                 "Binds" to formatVolumeMounts()
+                "Devices" to formatDeviceMounts()
                 "PortBindings" to formatPortMappings()
                 "Privileged" to privileged
                 "Init" to init
@@ -102,6 +105,13 @@ data class DockerContainerCreationRequest(
     private fun formatVolumeMounts(): JsonArray = volumeMounts
         .map { it.toString() }
         .toJsonArray()
+
+    private fun formatDeviceMounts(): JsonArray = JsonArray(deviceMounts
+        .map { json {
+            "PathOnHost" to it.localPath
+            "PathInContainer" to it.containerPath
+            "CgroupPermissions" to it.options
+        } })
 
     private fun formatPortMappings(): JsonObject = json {
         portMappings.forEach {

--- a/app/src/main/kotlin/batect/docker/DockerContainerCreationRequestFactory.kt
+++ b/app/src/main/kotlin/batect/docker/DockerContainerCreationRequestFactory.kt
@@ -44,6 +44,7 @@ class DockerContainerCreationRequestFactory(
             environmentVariableProvider.environmentVariablesFor(container, config, propagateProxyEnvironmentVariables, terminalType, allContainersInNetwork),
             config.workingDirectory,
             container.volumeMounts + additionalVolumeMounts,
+            container.deviceMounts,
             container.portMappings + config.additionalPortMappings,
             container.healthCheckConfig,
             userAndGroup,

--- a/app/src/unitTest/kotlin/batect/config/ConfigurationSpec.kt
+++ b/app/src/unitTest/kotlin/batect/config/ConfigurationSpec.kt
@@ -88,7 +88,7 @@ object ConfigurationSpec : Spek({
                 }
             }
 
-            given("a single container that pulls an image and runs as the current user") {
+            given("a single container with many options that pulls an image and runs as the current user") {
                 val container = Container(
                     "the-container",
                     PullImage("the-image"),
@@ -97,6 +97,7 @@ object ConfigurationSpec : Spek({
                     mapOf("SOME_VAR" to LiteralValue("some-value")),
                     "/some/working/dir",
                     setOf(VolumeMount("/local/path", "/container/path", "some-options")),
+                    setOf(DeviceMount("/dev/local", "/dev/container", "device-options")),
                     setOf(PortMapping(123, 456)),
                     setOf("other-container"),
                     HealthCheckConfig(Duration.ofSeconds(1), 23, Duration.ofSeconds(4)),
@@ -134,6 +135,13 @@ object ConfigurationSpec : Spek({
                                             "options": "some-options"
                                         }
                                     ],
+                                    "devices": [
+                                        {
+                                            "local": "/dev/local",
+                                            "container": "/dev/container",
+                                            "options": "device-options"
+                                        }
+                                    ],
                                     "ports": [
                                         { "local": 123, "container": 456 }
                                     ],
@@ -162,7 +170,7 @@ object ConfigurationSpec : Spek({
                 }
             }
 
-            given("a single container that builds an image and runs as the default container user") {
+            given("a single container with few options that builds an image and runs as the default container user") {
                 val container = Container(
                     "the-container",
                     BuildImage(
@@ -200,6 +208,7 @@ object ConfigurationSpec : Spek({
                                     "environment": {},
                                     "working_directory": null,
                                     "volumes": [],
+                                    "devices": [],
                                     "ports": [],
                                     "dependencies": [],
                                     "health_check": {

--- a/app/src/unitTest/kotlin/batect/config/ContainerSpec.kt
+++ b/app/src/unitTest/kotlin/batect/config/ContainerSpec.kt
@@ -210,6 +210,9 @@ object ContainerSpec : Spek({
                 volumes:
                   - /volume1:/here
                   - /somewhere:/else:ro
+                devices:
+                  - /dev/ttyUSB0:/dev/ttyUSB0
+                  - /dev/sda:/dev/xvdc:r
                 ports:
                   - "1234:5678"
                   - "9012:3456"
@@ -258,6 +261,14 @@ object ContainerSpec : Spek({
                             setOf(
                                 VolumeMount("/resolved/volume1", "/here", null),
                                 VolumeMount("/resolved/somewhere", "/else", "ro")
+                            )
+                        )
+                    )
+                    assertThat(
+                        result.deviceMounts, equalTo(
+                            setOf(
+                                DeviceMount("/dev/ttyUSB0", "/dev/ttyUSB0", null),
+                                DeviceMount("/dev/sda", "/dev/xvdc", "r")
                             )
                         )
                     )

--- a/app/src/unitTest/kotlin/batect/config/DeviceMountSpec.kt
+++ b/app/src/unitTest/kotlin/batect/config/DeviceMountSpec.kt
@@ -16,12 +16,8 @@
 
 package batect.config
 
-import batect.config.io.deserializers.PathDeserializer
-import batect.os.PathResolutionResult
-import batect.os.PathType
 import batect.testutils.createForEachTest
 import batect.testutils.on
-import batect.testutils.osIndependentPath
 import batect.testutils.runForEachTest
 import batect.testutils.withColumn
 import batect.testutils.withLineNumber
@@ -32,34 +28,17 @@ import com.natpryce.hamkrest.and
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import com.natpryce.hamkrest.throws
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.doAnswer
-import com.nhaarman.mockitokotlin2.mock
-import kotlinx.serialization.Decoder
-import kotlinx.serialization.modules.serializersModuleOf
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
 object DeviceMountSpec : Spek({
     describe("a device mount") {
         describe("deserializing from YAML") {
-            val pathDeserializer by createForEachTest {
-                mock<PathDeserializer> {
-                    on { deserialize(any()) } doAnswer { invocation ->
-                        val input = invocation.arguments[0] as Decoder
 
-                        when (val originalPath = input.decodeString()) {
-                            "/invalid" -> PathResolutionResult.InvalidPath(originalPath)
-                            else -> PathResolutionResult.Resolved(originalPath, osIndependentPath(originalPath), PathType.Other)
-                        }
-                    }
-                }
-            }
-
-            val parser by createForEachTest { Yaml(context = serializersModuleOf(PathResolutionResult::class, pathDeserializer)) }
+            val parser by createForEachTest { Yaml() }
 
             describe("deserializing from compact form") {
-                on("parsing a valid device mount definition") {
+                on("parsing a valid device mount definition without options") {
                     val deviceMount by runForEachTest { parser.parse(DeviceMount.Companion, "'/local:/container'") }
 
                     it("returns the correct local path") {

--- a/app/src/unitTest/kotlin/batect/config/DeviceMountSpec.kt
+++ b/app/src/unitTest/kotlin/batect/config/DeviceMountSpec.kt
@@ -1,0 +1,227 @@
+/*
+   Copyright 2017-2019 Charles Korn.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package batect.config
+
+import batect.config.io.deserializers.PathDeserializer
+import batect.os.PathResolutionResult
+import batect.os.PathType
+import batect.testutils.createForEachTest
+import batect.testutils.on
+import batect.testutils.osIndependentPath
+import batect.testutils.runForEachTest
+import batect.testutils.withColumn
+import batect.testutils.withLineNumber
+import batect.testutils.withMessage
+import com.charleskorn.kaml.Yaml
+import com.natpryce.hamkrest.absent
+import com.natpryce.hamkrest.and
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import com.natpryce.hamkrest.throws
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doAnswer
+import com.nhaarman.mockitokotlin2.mock
+import kotlinx.serialization.Decoder
+import kotlinx.serialization.modules.serializersModuleOf
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+object DeviceMountSpec : Spek({
+    describe("a device mount") {
+        describe("deserializing from YAML") {
+            val pathDeserializer by createForEachTest {
+                mock<PathDeserializer> {
+                    on { deserialize(any()) } doAnswer { invocation ->
+                        val input = invocation.arguments[0] as Decoder
+
+                        when (val originalPath = input.decodeString()) {
+                            "/invalid" -> PathResolutionResult.InvalidPath(originalPath)
+                            else -> PathResolutionResult.Resolved(originalPath, osIndependentPath(originalPath), PathType.Other)
+                        }
+                    }
+                }
+            }
+
+            val parser by createForEachTest { Yaml(context = serializersModuleOf(PathResolutionResult::class, pathDeserializer)) }
+
+            describe("deserializing from compact form") {
+                on("parsing a valid device mount definition") {
+                    val deviceMount by runForEachTest { parser.parse(DeviceMount.Companion, "'/local:/container'") }
+
+                    it("returns the correct local path") {
+                        assertThat(deviceMount.localPath, equalTo("/local"))
+                    }
+
+                    it("returns the correct container path") {
+                        assertThat(deviceMount.containerPath, equalTo("/container"))
+                    }
+
+                    it("returns the correct options") {
+                        assertThat(deviceMount.options, absent())
+                    }
+
+                    it("returns the correct string form") {
+                        assertThat(deviceMount.toString(), equalTo("/local:/container"))
+                    }
+                }
+
+                on("parsing a valid device mount definition with options") {
+                    val deviceMount by runForEachTest { parser.parse(DeviceMount.Companion, "'/local:/container:some_options'") }
+
+                    it("returns the correct local path") {
+                        assertThat(deviceMount.localPath, equalTo("/local"))
+                    }
+
+                    it("returns the correct container path") {
+                        assertThat(deviceMount.containerPath, equalTo("/container"))
+                    }
+
+                    it("returns the correct options") {
+                        assertThat(deviceMount.options, equalTo("some_options"))
+                    }
+
+                    it("returns the correct string form") {
+                        assertThat(deviceMount.toString(), equalTo("/local:/container:some_options"))
+                    }
+                }
+
+                on("parsing an empty device mount definition") {
+                    it("fails with an appropriate error message") {
+                        assertThat({ parser.parse(DeviceMount.Companion, "''") }, throws(withMessage("Device mount definition cannot be empty.") and withLineNumber(1) and withColumn(1)))
+                    }
+                }
+
+                listOf(
+                    "thing:",
+                    ":thing",
+                    "thing",
+                    " ",
+                    ":",
+                    "thing:thing:",
+                    "thing:thing:options:"
+                ).map {
+                    on("parsing the invalid device mount definition '$it'") {
+                        it("fails with an appropriate error message") {
+                            assertThat(
+                                { parser.parse(DeviceMount.Companion, "'$it'") }, throws(
+                                    withMessage("Device mount definition '$it' is not valid. It must be in the form 'local_path:container_path' or 'local_path:container_path:options'.")
+                                        and withLineNumber(1)
+                                        and withColumn(1)
+                                )
+                            )
+                        }
+                    }
+                }
+            }
+
+            describe("deserializing from expanded form") {
+                on("parsing a valid device mount definition") {
+                    val yaml = """
+                            local: /local
+                            container: /container
+                        """.trimIndent()
+
+                    val deviceMount by runForEachTest { parser.parse(DeviceMount.Companion, yaml) }
+
+                    it("returns the correct local path") {
+                        assertThat(deviceMount.localPath, equalTo("/local"))
+                    }
+
+                    it("returns the correct container path") {
+                        assertThat(deviceMount.containerPath, equalTo("/container"))
+                    }
+
+                    it("returns the correct options") {
+                        assertThat(deviceMount.options, absent())
+                    }
+
+                    it("returns the correct string form") {
+                        assertThat(deviceMount.toString(), equalTo("/local:/container"))
+                    }
+                }
+
+                on("parsing a valid device mount definition with options") {
+                    val yaml = """
+                            local: /local
+                            container: /container
+                            options: some_options
+                        """.trimIndent()
+
+                    val deviceMount by runForEachTest { parser.parse(DeviceMount.Companion, yaml) }
+
+                    it("returns the correct local path") {
+                        assertThat(deviceMount.localPath, equalTo("/local"))
+                    }
+
+                    it("returns the correct container path") {
+                        assertThat(deviceMount.containerPath, equalTo("/container"))
+                    }
+
+                    it("returns the correct options") {
+                        assertThat(deviceMount.options, equalTo("some_options"))
+                    }
+
+                    it("returns the correct string form") {
+                        assertThat(deviceMount.toString(), equalTo("/local:/container:some_options"))
+                    }
+                }
+
+                on("parsing a device mount definition missing the 'local' field") {
+                    val yaml = "container: /container"
+
+                    it("fails with an appropriate error message") {
+                        assertThat(
+                            { parser.parse(DeviceMount.Companion, yaml) }, throws(
+                                withMessage("Field 'local' is required but it is missing.")
+                                    and withLineNumber(1)
+                                    and withColumn(1)
+                            )
+                        )
+                    }
+                }
+
+                on("parsing a device mount definition missing the 'container' field") {
+                    val yaml = "local: /local"
+
+                    it("fails with an appropriate error message") {
+                        assertThat(
+                            { parser.parse(DeviceMount.Companion, yaml) }, throws(
+                                withMessage("Field 'container' is required but it is missing.")
+                                    and withLineNumber(1)
+                                    and withColumn(1)
+                            )
+                        )
+                    }
+                }
+            }
+
+            describe("deserializing from something that is neither a string nor a map") {
+                val yaml = """
+                    - thing
+                """.trimIndent()
+
+                it("fails with an appropriate error message") {
+                    assertThat(
+                        { parser.parse(DeviceMount.Companion, yaml) }, throws(
+                            withMessage("Device mount definition is not valid. It must either be an object or a literal in the form 'local_path:container_path' or 'local_path:container_path:options'.")
+                        )
+                    )
+                }
+            }
+        }
+    }
+})

--- a/app/src/unitTest/kotlin/batect/config/VolumeMountSpec.kt
+++ b/app/src/unitTest/kotlin/batect/config/VolumeMountSpec.kt
@@ -101,7 +101,7 @@ object VolumeMountSpec : Spek({
 
                 mapOf(
                     "c:\\local" to "a lowercase drive letter",
-                    "C:\\local" to "a uppercase drive letter"
+                    "C:\\local" to "an uppercase drive letter"
                 ).forEach { (local, description) ->
                     on("parsing a valid Windows volume mount definition with $description") {
                         val volumeMount by runForEachTest { parser.parse(VolumeMount.Companion, "'$local:/container'") }

--- a/app/src/unitTest/kotlin/batect/docker/DockerContainerCreationRequestFactorySpec.kt
+++ b/app/src/unitTest/kotlin/batect/docker/DockerContainerCreationRequestFactorySpec.kt
@@ -20,6 +20,7 @@ import batect.config.Container
 import batect.config.HealthCheckConfig
 import batect.config.LiteralValue
 import batect.config.PortMapping
+import batect.config.DeviceMount
 import batect.config.VolumeMount
 import batect.execution.ContainerRuntimeConfiguration
 import batect.os.Command
@@ -73,6 +74,7 @@ object DockerContainerCreationRequestFactorySpec : Spek({
                         entrypoint = Command.parse("some-command-that-wont-be-used"),
                         workingDirectory = "/some-work-dir",
                         volumeMounts = setOf(VolumeMount("local", "remote", "mode")),
+                        deviceMounts = setOf(DeviceMount("/dev/local", "/dev/container", "options")),
                         portMappings = setOf(PortMapping(123, 456)),
                         healthCheckConfig = HealthCheckConfig(Duration.ofSeconds(2), 10, Duration.ofSeconds(5)),
                         privileged = false,
@@ -130,6 +132,10 @@ object DockerContainerCreationRequestFactorySpec : Spek({
 
                     it("populates the volume mounts on the request with the volume mounts from the container") {
                         assertThat(request.volumeMounts, equalTo(container.volumeMounts))
+                    }
+
+                    it("populates the device mounts on the request with the device mounts from the container") {
+                        assertThat(request.deviceMounts, equalTo(container.deviceMounts))
                     }
 
                     it("populates the port mappings on the request with the port mappings from the container") {

--- a/app/src/unitTest/kotlin/batect/docker/DockerContainerCreationRequestSpec.kt
+++ b/app/src/unitTest/kotlin/batect/docker/DockerContainerCreationRequestSpec.kt
@@ -16,6 +16,7 @@
 
 package batect.docker
 
+import batect.config.DeviceMount
 import batect.config.HealthCheckConfig
 import batect.config.PortMapping
 import batect.config.VolumeMount
@@ -40,6 +41,7 @@ object DockerContainerCreationRequestSpec : Spek({
                 mapOf("SOME_VAR" to "some value"),
                 "/work-dir",
                 setOf(VolumeMount("/local", "/container", "ro")),
+                setOf(DeviceMount("/dev/local", "/dev/container", "rw")),
                 setOf(PortMapping(123, 456)),
                 HealthCheckConfig(Duration.ofNanos(555), 12, Duration.ofNanos(333)),
                 UserAndGroup(789, 222),
@@ -76,6 +78,13 @@ object DockerContainerCreationRequestSpec : Spek({
                         |       "NetworkMode": "the-network",
                         |       "Binds": [
                         |           "/local:/container:ro"
+                        |       ],
+                        |       "Devices": [
+                        |           {
+                        |               "PathOnHost": "/dev/local",
+                        |               "PathInContainer": "/dev/container",
+                        |               "CgroupPermissions": "rw"
+                        |           }
                         |       ],
                         |       "PortBindings": {
                         |           "456/tcp": [
@@ -123,6 +132,7 @@ object DockerContainerCreationRequestSpec : Spek({
                 null,
                 emptySet(),
                 emptySet(),
+                emptySet(),
                 HealthCheckConfig(),
                 null,
                 privileged = false,
@@ -149,6 +159,7 @@ object DockerContainerCreationRequestSpec : Spek({
                         |   "HostConfig": {
                         |       "NetworkMode": "the-network",
                         |       "Binds": [],
+                        |       "Devices": [],
                         |       "PortBindings": {},
                         |       "Privileged": false,
                         |       "Init": false,

--- a/app/src/unitTest/kotlin/batect/docker/api/ContainersAPISpec.kt
+++ b/app/src/unitTest/kotlin/batect/docker/api/ContainersAPISpec.kt
@@ -117,7 +117,7 @@ object ContainersAPISpec : Spek({
                 val command = listOf("doStuff")
                 val entrypoint = listOf("sh")
                 val request =
-                    DockerContainerCreationRequest(image, network, command, entrypoint, "some-host", setOf("some-host"), emptyMap(), "/some-dir", emptySet(), emptySet(), HealthCheckConfig(), null, false, false, emptySet(), emptySet())
+                    DockerContainerCreationRequest(image, network, command, entrypoint, "some-host", setOf("some-host"), emptyMap(), "/some-dir", emptySet(), emptySet(), emptySet(), HealthCheckConfig(), null, false, false, emptySet(), emptySet())
 
                 on("a successful creation") {
                     val call by createForEachTest { clientWithLongTimeout.mockPost(expectedUrl, """{"Id": "abc123"}""", 201) }

--- a/app/src/unitTest/kotlin/batect/docker/client/DockerContainersClientSpec.kt
+++ b/app/src/unitTest/kotlin/batect/docker/client/DockerContainersClientSpec.kt
@@ -83,7 +83,7 @@ object DockerContainersClientSpec : Spek({
                 val network = DockerNetwork("the-network")
                 val command = listOf("doStuff")
                 val entrypoint = listOf("sh")
-                val request = DockerContainerCreationRequest(image, network, command, entrypoint, "some-host", setOf("some-host"), emptyMap(), "/some-dir", emptySet(), emptySet(), HealthCheckConfig(), null, false, false, emptySet(), emptySet())
+                val request = DockerContainerCreationRequest(image, network, command, entrypoint, "some-host", setOf("some-host"), emptyMap(), "/some-dir", emptySet(), emptySet(), emptySet(), HealthCheckConfig(), null, false, false, emptySet(), emptySet())
 
                 on("creating the container") {
                     beforeEachTest { whenever(api.create(request)).doReturn(DockerContainer("abc123")) }

--- a/app/src/unitTest/kotlin/batect/execution/model/steps/TaskStepRunnerSpec.kt
+++ b/app/src/unitTest/kotlin/batect/execution/model/steps/TaskStepRunnerSpec.kt
@@ -351,7 +351,7 @@ object TaskStepRunnerSpec : Spek({
 
                 val config = mock<ContainerRuntimeConfiguration>()
                 val step = CreateContainerStep(container, config, setOf(container, otherContainer), image, network)
-                val request = DockerContainerCreationRequest(image, network, Command.parse("do-stuff").parsedCommand, Command.parse("sh").parsedCommand, "some-container", setOf("some-container"), emptyMap(), "/work-dir", emptySet(), emptySet(), HealthCheckConfig(), null, false, false, emptySet(), emptySet())
+                val request = DockerContainerCreationRequest(image, network, Command.parse("do-stuff").parsedCommand, Command.parse("sh").parsedCommand, "some-container", setOf("some-container"), emptyMap(), "/work-dir", emptySet(), emptySet(), emptySet(), HealthCheckConfig(), null, false, false, emptySet(), emptySet())
 
                 beforeEachTest {
                     whenever(ioStreamingOptions.terminalTypeForContainer(container)).doReturn("some-terminal")

--- a/docs/content/config/Containers.md
+++ b/docs/content/config/Containers.md
@@ -150,7 +150,7 @@ Relative local paths will be resolved relative to the configuration file's direc
 
 Two formats are supported:
 
-* Standard Docker `local:container` or `local:container:mode` format
+* Standard Docker `local:container` or `local:container:options` format
 
 * An expanded format:
   ```yaml
@@ -168,6 +168,27 @@ On Windows, the local path can use either Windows-style (`path\to\thing`) or Uni
 with users running on other operating systems, using Unix-style paths is recommended.
 
 See [this page](../tips/Performance.md#io-performance) for more information on why using `cached` volume mounts may be worthwhile.
+
+## `devices`
+List of device mounts to create for the container.
+
+Two formats are supported:
+
+* Standard Docker `local:container` or `local:container:options` format
+
+* An expanded format:
+  ```yaml
+  containers:
+    my-container:
+      ...
+      devices:
+      # This is equivalent to /dev/sda:/dev/disk:r
+      - local: /dev/sda
+        container: /dev/disk
+        options: r
+  ```
+
+Note that the `local` device mounts will be different for Windows and Unix-like hosts. See the [Docker guide for adding host devices to containers](https://docs.docker.com/engine/reference/commandline/run/#add-host-device-to-container---device) for more information.
 
 ## `ports`
 List of ports to make available to the host machine.

--- a/docs/content/config/Containers.md
+++ b/docs/content/config/Containers.md
@@ -190,6 +190,8 @@ Two formats are supported:
 
 Note that the `local` device mounts will be different for Windows and Unix-like hosts. See the [Docker guide for adding host devices to containers](https://docs.docker.com/engine/reference/commandline/run/#add-host-device-to-container---device) for more information.
 
+Available since v0.39.
+
 ## `ports`
 List of ports to make available to the host machine.
 


### PR DESCRIPTION
Started as Hacktober project for me and @wilvk.

Allow specific devices can be mounted from host to container. PR includes code, unit tests, integration tests and documentation update. Happy to make changes before merge.

The example `batect.yaml` is now possible:
```
containers:
  build-env:
    image: openjdk:8u181-jdk
    devices:
      - local: /dev/sda
        container: /dev/xvdc
        options: r
...
```